### PR TITLE
Revert "Adds getAll to fetch all edges with name and from_node"

### DIFF
--- a/include/document_graph/edge.hpp
+++ b/include/document_graph/edge.hpp
@@ -49,10 +49,6 @@ namespace hypha
                         const eosio::checksum256 &from_node,
                         const eosio::name &edge_name);
 
-        static std::vector<Edge> getAll(const eosio::name &_contract,
-                           const eosio::checksum256 &_from_node,
-                           const eosio::name &_edge_name);
-
         static bool exists(const eosio::name &_contract,
                            const eosio::checksum256 &_from_node,
                            const eosio::checksum256 &_to_node,

--- a/src/document_graph/edge.cpp
+++ b/src/document_graph/edge.cpp
@@ -87,22 +87,6 @@ namespace hypha
     }
 
     // static getter
-    std::vector<Edge> Edge::getAll(const eosio::name &_contract,
-                      const eosio::checksum256 &_from_node,
-                      const eosio::name &_edge_name)
-    {
-        edge_table e_t(_contract, _contract.value);
-        auto fromEdgeIndex = e_t.get_index<eosio::name("byfromname")>();
-        auto index = concatHash(_from_node, _edge_name);
-        std::vector<Edge> edges;
-        for (auto itr = fromEdgeIndex.find(index); itr != fromEdgeIndex.end(); ++itr) {
-            edges.push_back(*itr);
-        }
-
-        return edges;
-    }
-
-    // static getter
     std::pair<bool, Edge> Edge::getIfExists(const eosio::name &_contract,
                                             const eosio::checksum256 &_from_node,
                                             const eosio::name &_edge_name)


### PR DESCRIPTION
Method not completely implemented, missing some features to ensure it
works correctly. Better implementation is found on DocumentGraph
This reverts commit c1fcd824cae6e2048c44ea689fa5212d26e7771f.

Removing this as is missing the index check and to avoid duplicating code.